### PR TITLE
Update _config.yml to hide unnecessary Atom feed

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -3,10 +3,12 @@ description: GitHub Enterpriseユーザーのためのイベントアーカイ�
 remote_theme: mmistakes/minimal-mistakes
 plugins:
   - jekyll-include-cache
-  - jekyll-feed
 
 # メニュー設定（必要に応じて）
 nav:
   - title: "イベント一覧"
     url: "https://octonihon.github.io"
     baseurl: "/events"
+
+atom_feed:
+ hide: true


### PR DESCRIPTION
This pull request makes a small update to the `_config.yml` file. The change removes the `jekyll-feed` plugin and adds a new configuration to hide the `atom_feed`.